### PR TITLE
Standardize dark link variables

### DIFF
--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -82,8 +82,6 @@
 
   // Typography
   --text-color: var(--black);
-  --text-color-primary: var(--primary);
-  --text-color-primary-accent: var(--primary-active);
   --text-color-grey-light: #747c82;
   --text-inactive: var(--text-color-grey-light);
 
@@ -106,6 +104,9 @@
   // Link
   --link-color: #204a87;
   --link-visited-color: #5c3566;
+  --link-dark-color: var(--black);
+  --link-dark-color-hover: var(--primary);
+  --link-dark-color-pressed: var(--primary-active);
 
   // Pane
   --pane-header-color: #eee;

--- a/war/src/main/less/abstracts/colors.less
+++ b/war/src/main/less/abstracts/colors.less
@@ -105,8 +105,8 @@
   --link-color: #204a87;
   --link-visited-color: #5c3566;
   --link-dark-color: var(--black);
-  --link-dark-color-hover: var(--primary);
-  --link-dark-color-pressed: var(--primary-active);
+  --link-dark-color--hover: var(--primary);
+  --link-dark-color--active: var(--primary-active);
 
   // Pane
   --pane-header-color: #eee;

--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -63,12 +63,12 @@
 
   &:focus,
   &:hover {
-    color: var(--link-dark-color-hover);
+    color: var(--link-dark-color--hover);
     text-decoration: underline;
   }
 
   &:active {
-    color: var(--link-dark-color-pressed);
+    color: var(--link-dark-color--active);
     text-decoration: underline;
   }
 }

--- a/war/src/main/less/modules/page-footer.less
+++ b/war/src/main/less/modules/page-footer.less
@@ -58,17 +58,17 @@
   &:visited {
     font-weight: 600;
     text-decoration: none;
-    color: var(--text-color);
+    color: var(--link-dark-color);
   }
 
   &:focus,
   &:hover {
-    color: var(--text-color-primary);
+    color: var(--link-dark-color-hover);
     text-decoration: underline;
   }
 
   &:active {
-    color: var(--text-color-primary-accent);
+    color: var(--link-dark-color-pressed);
     text-decoration: underline;
   }
 }

--- a/war/src/main/less/modules/side-panel-tasks.less
+++ b/war/src/main/less/modules/side-panel-tasks.less
@@ -44,7 +44,7 @@
 }
 .task-link:link,
 .task-link:visited {
-  color: var(--text-color);
+  color: var(--link-dark-color);
   text-decoration: none;
 
   &:hover,
@@ -53,7 +53,7 @@
   }
 
   &:active {
-    background-color: #EAEFF2;
+    background-color: var(--task-link-background-color--active);
   }
 
   &:focus {


### PR DESCRIPTION
In order to future-proof the dark hyperlinks I propose to consolidate their styles in some new variables: 

- `--link-dark-color`
- `--link-dark-color-hover`
- `--link-dark-color-pressed`

The reason for this is that my soon to land work on the widgets uses this component heavily, and I think it's going to be a standard.

This PR also removes some unused variables and fixes one active color for the sidebar tasks.